### PR TITLE
throw an exception when server doesn't give us list of mechanisms

### DIFF
--- a/lib/XmppPrebind.php
+++ b/lib/XmppPrebind.php
@@ -133,7 +133,12 @@ class XmppPrebind {
 		$this->sid = $body->getAttribute('sid');
 		$this->debug($this->sid, 'sid');
 
-		$mechanisms = $body->firstChild->firstChild->getElementsByTagName('mechanism');
+		$child = $body->firstChild->firstChild;
+		if (is_object($child)) {
+			$mechanisms = $child->getElementsByTagName('mechanism');
+		} else {
+			throw new Exception('Invalid response');
+		}
 
 		foreach ($mechanisms as $value) {
 			$this->mechanisms[] = $value->nodeValue;


### PR DESCRIPTION
previously, an error stanza from the server will result in uncatchable PHP Fatal Error.
