### PR TITLE
fix issue with autoload

### DIFF
--- a/lib/XmppPrebind.php
+++ b/lib/XmppPrebind.php
@@ -12,11 +12,6 @@
 include 'FirePHP/fb.php';
 
 /**
- * PEAR Auth_SASL
- */
-require 'Auth/SASL.php';
-
-/**
  * XMPP Library for connecting to jabber server & receiving sid and rid
  */
 class XmppPrebind {


### PR DESCRIPTION
Under some conditons as in the following example there is an error

PHP Fatal error:  Cannot redeclare class Auth_SASL in /usr/share/php/Auth/SASL.php on line 49

```php
<?php

include __DIR__ . '/vendor/autoload.php';


$auth = Auth_SASL::factory('PLAIN');
$bind = new XmppPrebind();
....
```