### PR TITLE
feat(prebind): added boshparameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 .svn
+.idea

--- a/lib/XmppPrebind.php
+++ b/lib/XmppPrebind.php
@@ -66,16 +66,16 @@ class XmppPrebind {
 	protected $mechanisms = array();
 
 	// the Bosh attributes for use in a client using this prebound session
-	protected $wait,
-			$requests,
-			$ver,
-			$polling,
-			$inactivity,
-			$hold,
-			$to,
-			$ack,
-			$accept,
-			$maxpause;
+	protected $wait;
+	protected $requests;
+	protected $ver;
+	protected $polling;
+	protected $inactivity;
+	protected $hold;
+	protected $to;
+	protected $ack;
+	protected $accept;
+	protected $maxpause;
 
 	/**
 	 * Session creation response
@@ -226,16 +226,16 @@ class XmppPrebind {
 	public function getBoshInfo()
 	{
 		return array(
-				'wait' => $this->wait,
-				'requests' => $this->requests,
-				'ver' => $this->ver,
-				'polling' => $this->polling,
-				'inactivity' => $this->inactivity,
-				'hold' => $this->hold,
-				'to' => $this->to,
-				'ack' => $this->ack,
-				'accept' => $this->accept,
-				'maxpause' => $this->maxpause,
+			'wait' => $this->wait,
+			'requests' => $this->requests,
+			'ver' => $this->ver,
+			'polling' => $this->polling,
+			'inactivity' => $this->inactivity,
+			'hold' => $this->hold,
+			'to' => $this->to,
+			'ack' => $this->ack,
+			'accept' => $this->accept,
+			'maxpause' => $this->maxpause,
 		);
 	}
 

--- a/lib/XmppPrebind.php
+++ b/lib/XmppPrebind.php
@@ -272,7 +272,7 @@ class XmppPrebind {
 		$body->appendChild(self::getNewTextAttribute($domDocument, 'xmlns:xmpp', self::XMLNS_BOSH));
 		$body->appendChild(self::getNewTextAttribute($domDocument, 'xmpp:restart', 'true'));
 
-		$restartResponse = $this->send($domDocument->saveXML($body));
+		$restartResponse = $this->send($domDocument->saveXML());
 
 		$restartBody = self::getBodyFromXml($restartResponse);
 		foreach ($restartBody->childNodes as $bodyChildNodes) {
@@ -315,7 +315,7 @@ class XmppPrebind {
 			$iq->appendChild($bind);
 			$body->appendChild($iq);
 
-			return $this->send($domDocument->saveXML($body));
+			return $this->send($domDocument->saveXML());
 		}
 		return false;
 	}
@@ -339,7 +339,7 @@ class XmppPrebind {
 			$iq->appendChild($session);
 			$body->appendChild($iq);
 
-			return $this->send($domDocument->saveXML($body));
+			return $this->send($domDocument->saveXML());
 		}
 		return false;
 	}
@@ -367,7 +367,7 @@ class XmppPrebind {
 			$body->appendChild(self::getNewTextAttribute($domDocument, 'route', $route));
 		}
 
-		return $this->send($domDocument->saveXML($body));
+		return $this->send($domDocument->saveXML());
 	}
 
 	/**
@@ -384,7 +384,7 @@ class XmppPrebind {
 		$auth->appendChild(self::getNewTextAttribute($domDocument, 'mechanism', $this->encryption));
 		$body->appendChild($auth);
 
-		$response = $this->send($domDocument->saveXML($body));
+		$response = $this->send($domDocument->saveXML());
 
 		$body = $this->getBodyFromXml($response);
 		$challenge = base64_decode($body->firstChild->nodeValue);
@@ -439,7 +439,7 @@ class XmppPrebind {
 		$body->appendChild($response);
 
 
-		$challengeResponse = $this->send($domDocument->saveXML($body));
+		$challengeResponse = $this->send($domDocument->saveXML());
 
 		return $this->replyToChallengeResponse($challengeResponse);
 	}
@@ -467,7 +467,7 @@ class XmppPrebind {
 
 		$body->appendChild($response);
 
-		$challengeResponse = $this->send($domDocument->saveXML($body));
+		$challengeResponse = $this->send($domDocument->saveXML());
 
 		return $this->replyToChallengeResponse($challengeResponse);
 	}


### PR DESCRIPTION
My revised PR for BOSH connection parameters.

I now relay the BOSH parameters the connection manager returns on the initial request.  Also removed <?xml version="1.0" encoding="UTF-8"?> tag since it trips https://github.com/dhruvbird/node-xmpp-bosh and without it seems to work fine with Ejabberd BOSH connection manager.
