### PR TITLE
feat(prebind): catch bosh error

### DIFF
--- a/lib/XmppPrebind.php
+++ b/lib/XmppPrebind.php
@@ -138,7 +138,11 @@ class XmppPrebind {
 		$this->debug($this->sid, 'sid');
 
 		$mechanisms = $body->getElementsByTagName('mechanism');
-		
+
+		if (!preg_match('/^<body/', $response)) {
+			throw new XmppPrebindConnectionException("Cannot connect to service");
+		}
+
 		foreach ($mechanisms as $value) {
 			$this->mechanisms[] = $value->nodeValue;
 		}


### PR DESCRIPTION
Throw an error if the BOSH connection manager cannot be reached